### PR TITLE
[RPC] Make CommunicatorClient::StateChange() protected

### DIFF
--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -1242,8 +1242,10 @@ namespace RPC {
 			// Lock event until Dispatch() sets it.
 			return (_announceEvent.Lock(waitTime) == Core::ERROR_NONE);
 		}
-		virtual void StateChange();
 		virtual void Dispatch(Core::IIPC& element);
+
+	protected:
+		virtual void StateChange();
 
 	private:
 		Core::ProxyType<RPC::AnnounceMessage> _announceMessage;


### PR DESCRIPTION
The RPC::CommunicatorClient::StateChange() may have to be called by
derived classes overriding it, i.e., the derived class may have to call
the base class method when overriding it. This way, StateChange() cannot
be private, so make it protected instead.