### PR TITLE
WPEPlayer Changes while making playerPlatform implementation as archive

### DIFF
--- a/Source/interfaces/ITVControl.h
+++ b/Source/interfaces/ITVControl.h
@@ -36,13 +36,6 @@ namespace Exchange {
             struct IGeometry : virtual public Core::IUnknown {
                 enum { ID = 0x00000019 };
 
-                struct Rectangle {
-                     uint32_t X;
-                     uint32_t Y;
-                     uint32_t Width;
-                     uint32_t Height;
-                };
-
                 virtual ~IGeometry() {}
 
                 virtual uint32_t X() const = 0;;
@@ -93,18 +86,30 @@ namespace Exchange {
 
     struct IPlayer : virtual public Core::IUnknown {
         enum { ID = 0x00000015 };
-        struct ICallback {
-            virtual ~ICallback() {}
-
-            virtual void TimeUpdate(uint64_t position) = 0;
-            virtual void DRM(uint32_t state) = 0;
-            virtual void StateChange(Exchange::IStream::state newState) = 0;
-        };
 
         virtual ~IPlayer() {}
         virtual IStream* CreateStream(IStream::streamtype streamType) = 0;
         virtual uint32_t Configure(PluginHost::IShell* service) = 0;
     };
-}
-}
+} // namespace Exchange
+
+namespace Player {
+namespace Implementation {
+
+    struct Rectangle {
+        uint32_t X;
+        uint32_t Y;
+        uint32_t Width;
+        uint32_t Height;
+    };
+
+    struct ICallback {
+        virtual ~ICallback() {}
+
+        virtual void TimeUpdate(uint64_t position) = 0;
+        virtual void DRM(uint32_t state) = 0;
+        virtual void StateChange(Exchange::IStream::state newState) = 0;
+    };
+} } // // namespace Player::Implementation
+} // namespace WPEFramework
 #endif //_ITVCONTROL_H

--- a/Source/interfaces/ITVControl.h
+++ b/Source/interfaces/ITVControl.h
@@ -3,7 +3,7 @@
 
 #include "Module.h"
 
-#define LINEARBROADCASTPLAYER_PROCESS_NODE_ID "/tmp/LinearBroadcastPlayerProcess0"
+#define WPEPLAYER_PROCESS_NODE_ID "/tmp/player"
 
 namespace WPEFramework {
 namespace Exchange {
@@ -36,6 +36,13 @@ namespace Exchange {
             struct IGeometry : virtual public Core::IUnknown {
                 enum { ID = 0x00000019 };
 
+                struct Rectangle {
+                     uint32_t X;
+                     uint32_t Y;
+                     uint32_t Width;
+                     uint32_t Height;
+                };
+
                 virtual ~IGeometry() {}
 
                 virtual uint32_t X() const = 0;;
@@ -55,8 +62,8 @@ namespace Exchange {
 
             virtual ~IControl() {};
 
-            virtual void Speed(const uint32_t request) = 0;
-            virtual uint32_t Speed() const = 0;
+            virtual void Speed(const int32_t request) = 0;
+            virtual int32_t Speed() const = 0;
             virtual void Position(const uint64_t absoluteTime) = 0;
             virtual uint64_t Position() const = 0;
             virtual void TimeRange(uint64_t& begin, uint64_t& end) const = 0;
@@ -86,6 +93,13 @@ namespace Exchange {
 
     struct IPlayer : virtual public Core::IUnknown {
         enum { ID = 0x00000015 };
+        struct ICallback {
+            virtual ~ICallback() {}
+
+            virtual void TimeUpdate(uint64_t position) = 0;
+            virtual void DRM(uint32_t state) = 0;
+            virtual void StateChange(Exchange::IStream::state newState) = 0;
+        };
 
         virtual ~IPlayer() {}
         virtual IStream* CreateStream(IStream::streamtype streamType) = 0;

--- a/Source/interfaces/ProxyStubs.cpp
+++ b/Source/interfaces/ProxyStubs.cpp
@@ -1256,18 +1256,18 @@ namespace ProxyStubs {
     ProxyStub::MethodHandler StreamControlStubMethods[] = {
         [](Core::ProxyType<Core::IPCChannel>& channel, Core::ProxyType<RPC::InvokeMessage>& message) {
             //
-            // virtual void Speed(uint32_t request) = 0;
+            // virtual void Speed(int32_t request) = 0;
             //
             RPC::Data::Frame::Reader parameters(message->Parameters().Reader());
-            const uint32_t request(parameters.Number<uint32_t>());
+            const int32_t request(parameters.Number<int32_t>());
             message->Parameters().Implementation<IStream::IControl>()->Speed(request);
          },
          [](Core::ProxyType<Core::IPCChannel>& channel, Core::ProxyType<RPC::InvokeMessage>& message) {
              //
-             // virtual uint32_t Speed() const = 0;
+             // virtual int32_t Speed() const = 0;
              //
              RPC::Data::Frame::Writer response(message->Response().Writer());
-             response.Number<uint32_t>(message->Parameters().Implementation<IStream::IControl>()->Speed());
+             response.Number<int32_t>(message->Parameters().Implementation<IStream::IControl>()->Speed());
          },
          [](Core::ProxyType<Core::IPCChannel>& channel, Core::ProxyType<RPC::InvokeMessage>& message) {
              //
@@ -2782,19 +2782,19 @@ namespace ProxyStubs {
         {
         }
    public:
-        virtual void Speed(uint32_t request)
+        virtual void Speed(int32_t request)
         {
             IPCMessage newMessage(BaseClass::Message(0));
             RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());
-            writer.Number<uint32_t>(request);
+            writer.Number<int32_t>(request);
             Invoke(newMessage);
         }
-        virtual uint32_t Speed() const
+        virtual int32_t Speed() const
         {
             IPCMessage newMessage(BaseClass::Message(1));
             Invoke(newMessage);
 
-            return (newMessage->Response().Reader().Number<uint32_t>());
+            return (newMessage->Response().Reader().Number<int32_t>());
         }
         virtual void Position(uint64_t absoluteTime)
         {


### PR DESCRIPTION
1. Rectangle moved from Implementation::Geometry to IGeometry
2. Implementation::Callback moved to IPlayer
3. Data type of Speed interface changed from uint32_t to int32_t to support rewind in the trickily