### PR TITLE
[TRACE] Fix usage of '__VA_ARGS__' in variadic macros

### DIFF
--- a/Source/core/Trace.h
+++ b/Source/core/Trace.h
@@ -10,10 +10,10 @@
 
 #ifdef __WIN32__
 #define TRACE_PROCESS_ID ::GetCurrentProcessId()
-#define ASSERT_LOGGER(message, ...) fprintf(stderr, message, __VA_ARGS__);
+#define ASSERT_LOGGER(message, ...) fprintf(stderr, message, ##__VA_ARGS__);
 #else
 #define TRACE_PROCESS_ID ::getpid()
-#define ASSERT_LOGGER(message, ...) ::syslog(LOG_CRIT, message, __VA_ARGS__);
+#define ASSERT_LOGGER(message, ...) ::syslog(LOG_CRIT, message, ##__VA_ARGS__);
 #endif
 
 #ifndef _TRACE_LEVEL
@@ -28,7 +28,7 @@
 
 #if _TRACE_LEVEL > 4
 #define TRACE_L5(x, ...)							\
-    fprintf(stderr, "----- L5 [%d]: " #x "\n", TRACE_PROCESS_ID, __VA_ARGS__);	\
+    fprintf(stderr, "----- L5 [%d]: " #x "\n", TRACE_PROCESS_ID, ##__VA_ARGS__);	\
     fflush(stderr);
 #else
 #define TRACE_L5(x, ...)
@@ -36,7 +36,7 @@
 
 #if _TRACE_LEVEL > 3
 #define TRACE_L4(x, ...)							\
-    fprintf(stderr, "----  L4 [%d]: " #x "\n", TRACE_PROCESS_ID, __VA_ARGS__);	\
+    fprintf(stderr, "----  L4 [%d]: " #x "\n", TRACE_PROCESS_ID, ##__VA_ARGS__);	\
     fflush(stderr);
 #else
 #define TRACE_L4(x, ...)
@@ -44,7 +44,7 @@
 
 #if _TRACE_LEVEL > 2
 #define TRACE_L3(x, ...) 							\
-    fprintf(stderr, "---   L3 [%d]: " #x "\n", TRACE_PROCESS_ID, __VA_ARGS__);	\
+    fprintf(stderr, "---   L3 [%d]: " #x "\n", TRACE_PROCESS_ID, ##__VA_ARGS__);	\
     fflush(stderr);
 #else
 #define TRACE_L3(x, ...)
@@ -52,7 +52,7 @@
 
 #if _TRACE_LEVEL > 1
 #define TRACE_L2(x, ...) 							\
-    fprintf(stderr, "--    L2 [%d]: " #x "\n", TRACE_PROCESS_ID, __VA_ARGS__);	\
+    fprintf(stderr, "--    L2 [%d]: " #x "\n", TRACE_PROCESS_ID, ##__VA_ARGS__);	\
     fflush(stderr);
 #else
 #define TRACE_L2(x, ...)
@@ -60,7 +60,7 @@
 
 #if _TRACE_LEVEL > 0
 #define TRACE_L1(x, ...) 							\
-    fprintf(stderr, "-     L1 [%d]: " #x "\n", TRACE_PROCESS_ID, __VA_ARGS__);	\
+    fprintf(stderr, "-     L1 [%d]: " #x "\n", TRACE_PROCESS_ID, ##__VA_ARGS__);	\
     fflush(stderr);
 #else
 #define TRACE_L1(x, ...)
@@ -85,7 +85,7 @@
 
 #define ASSERT_VERBOSE(x, y, ...) {														\
     if (!(x)) {																	\
-        ASSERT_LOGGER("===== $$ [%d]: ASSERT [%s:%d] (" #x ")\n         " #y "\n", TRACE_PROCESS_ID, __FILE__, __LINE__, __VA_ARGS__)	\
+        ASSERT_LOGGER("===== $$ [%d]: ASSERT [%s:%d] (" #x ")\n         " #y "\n", TRACE_PROCESS_ID, __FILE__, __LINE__, ##__VA_ARGS__)	\
         DumpCallStack();															\
         assert(x);																\
     }																		\


### PR DESCRIPTION
The recommended way to use '__VA_ARGS__' in variadic macros, is to
prepend it with '##', to avoid problems with some compilers when the
macro is invoked with zero variable arguments (see [1]).

Not prepending '__VA_ARGS__' with '##' may result on build errors with
some compilers. This is actually happening with calls like:

    TRACE_L1("Some message with no variable arguments");

This way, replace all instances of '__VA_ARGS__' with '##__VA_ARGS__'.
Successfully build and runtime tested.

[1] https://gcc.gnu.org/onlinedocs/cpp/Variadic-Macros.html

Signed-off-by: Ricardo Silva <ricardo.silva@gbtembedded.com>