### PR TITLE
[OCDM] Fix missing lock Unlock() in OpenCDMAccessor::Release()

### DIFF
--- a/Source/ocdm/open_cdm.cpp
+++ b/Source/ocdm/open_cdm.cpp
@@ -756,17 +756,18 @@ public:
         Core::InterlockedIncrement(_refCount);
     }
     virtual uint32_t Release() const override {
+        uint32_t result = Core::ERROR_NONE;
 
         _systemLock.Lock();
 
         if (Core::InterlockedDecrement(_refCount) == 0) {
             delete this;
-            return (Core::ERROR_DESTRUCTION_SUCCEEDED);
+            result = Core::ERROR_DESTRUCTION_SUCCEEDED;
         }
 
         _systemLock.Unlock();
 
-        return (Core::ERROR_NONE);
+        return (result);
     }
     BEGIN_INTERFACE_MAP(OpenCDMAccessor)
         INTERFACE_ENTRY(OCDM::IAccessorOCDM)


### PR DESCRIPTION
When reaching a ref count of zero, OpenCDMAccessor::Release() has a
return path that doesn't release the _systemLock, which causes, e.g., a
new instance creation via OpenCDMAccessor::Instance() to deadlock as
soon as it tries to grab the _systemLock again.

Fix this unbalanced use of _systemLock in OpenCDMAccessor::Release() by
making sure all code paths release the lock.