### PR TITLE
[CyclicBuffer] Corrected lock issue.

### DIFF
--- a/Source/core/CyclicBuffer.cpp
+++ b/Source/core/CyclicBuffer.cpp
@@ -382,13 +382,9 @@ namespace Core {
 
                 _administration->_agents++;
 
-                AdminUnlock();
-
                 timeLeft = SignalLock(timeLeft);
 
                 _administration->_agents--;
-
-                AdminLock();
 
                 if (_alert == true) {
                     _alert = false;


### PR DESCRIPTION
I faced an issue while testing cyclic buffer in WPEFrameworkTests and corrected the same.