### PR TITLE
Fix compilation error

### DIFF
--- a/Source/jsonrpc/Channel.h
+++ b/Source/jsonrpc/Channel.h
@@ -405,7 +405,7 @@ namespace JSONRPC {
             return (result);
         }
         template <typename PARAMETERS = Core::JSON::VariantContainer, typename RESPONSE = Core::JSON::VariantContainer>
-        void Invoke(const uint32_t waitTime, const string& method, const PARAMETERS& parameters, std::function<void(const RESPONSE&)>& callback)
+        uint32_t Invoke(const uint32_t waitTime, const string& method, const PARAMETERS& parameters, std::function<void(const RESPONSE&)>& callback)
         {
             CallbackFunction implementation = [callback](const Core::JSONRPC::Message& inbound) -> void {
                 RESPONSE response;
@@ -422,7 +422,7 @@ namespace JSONRPC {
             return (result);
         }
         template <typename PARAMETERS = Core::JSON::VariantContainer, typename RESPONSE = Core::JSON::VariantContainer>
-        void Invoke(const uint32_t waitTime, const string& method, const PARAMETERS& parameters, std::function<void(const RESPONSE&, const Core::JSONRPC::Message::Info)>& callback)
+        uint32_t Invoke(const uint32_t waitTime, const string& method, const PARAMETERS& parameters, std::function<void(const RESPONSE&, const Core::JSONRPC::Message::Info)>& callback)
         {
             CallbackFunction implementation = [callback](const Core::JSONRPC::Message& inbound) -> void {
                 RESPONSE response;


### PR DESCRIPTION
Fixes the following error:

/home/dwrobel/projects/webkit/WebPlatformForEmbedded-2/WPEFramework/Source/jsonrpc/Channel.h: In member function ‘void WPEFramework::JSONRPC::Client::Invoke(uint32_t, const string&, const PARAMETERS&, std::function<void(const RESPONSE&)>&)’:
/home/dwrobel/projects/webkit/WebPlatformForEmbedded-2/WPEFramework/Source/jsonrpc/Channel.h:422:27: error: return-statement with a value, in function returning ‘void’ [-fpermissive]
             return (result);
                           ^
/home/dwrobel/projects/webkit/WebPlatformForEmbedded-2/WPEFramework/Source/jsonrpc/Channel.h: In member function ‘void WPEFramework::JSONRPC::Client::Invoke(uint32_t, const string&, const PARAMETERS&, std::function<void(const RESPONSE&, WPEFramework::Core::JSONRPC::Message::Info)>&)’:
/home/dwrobel/projects/webkit/WebPlatformForEmbedded-2/WPEFramework/Source/jsonrpc/Channel.h:440:27: error: return-statement with a value, in function returning ‘void’ [-fpermissive]
             return (result);
                           ^