### PR TITLE
Correct printf() arguments

### DIFF
--- a/Source/tracing/Logging.cpp
+++ b/Source/tracing/Logging.cpp
@@ -40,7 +40,7 @@ namespace Logging {
         } else
 #endif
         {
-            printf("[%11llu us] %s\n", static_cast<uint64_t>(now.Ticks() - _baseTime), information->Data());
+            printf("[%11ju us] %s\n", static_cast<uintmax_t>(now.Ticks() - _baseTime), information->Data());
         }
     }
 }


### PR DESCRIPTION
Fixes:

WPEFramework/Source/tracing/Logging.cpp:43:20: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 2 has type ‘uint64_t’ {aka ‘long unsigned int’} [-Wformat=]
             printf("[%11llu us] %s\n", static_cast<uint64_t>(now.Ticks() - _baseTime), information->Data());
                    ^