### PR TITLE
ASAN - Fix alloc-dealloc-mismatch in FrameType class

### DIFF
--- a/Source/core/Frame.h
+++ b/Source/core/Frame.h
@@ -17,13 +17,13 @@ namespace Core {
         public:
             AllocatorType()
                 : _bufferSize(STARTSIZE)
-                , _data(new uint8_t[_bufferSize])
+                , _data(reinterpret_cast<uint8_t*>(::malloc(_bufferSize)))
             {
                 static_assert(STARTSIZE != 0, "This method can only be called if you specify an initial blocksize");
             }
             AllocatorType(const AllocatorType<STARTSIZE>& copy)
                 : _bufferSize(copy._bufferSize)
-                , _data(STARTSIZE == 0 ? copy._data : new uint8_t[_bufferSize])
+                , _data(STARTSIZE == 0 ? copy._data : reinterpret_cast<uint8_t*>(::malloc(_bufferSize)))
             {
 
                 if (STARTSIZE != 0) {
@@ -39,7 +39,7 @@ namespace Core {
             ~AllocatorType()
             {
                 if ((STARTSIZE != 0) && (_data != nullptr)) {
-                    delete[] _data;
+                    ::free(_data);
                 }
             }
 


### PR DESCRIPTION
Fixes the following crash:

==26305==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs free) on 0x615000010700
-     L1 [26305]: "Network connectivity established on IPv4. ip: 91.230.58.69, tz: CET-1CEST,M3.5.0,M10.5.0/3, country: PL"
[     170129 us] EVENT: Internet [91.230.58.69]
[     170346 us] EVENT: TimeZone: CET-1CEST,M3.5.0,M10.5.0/3, Country: PL, Region: , City:
-     L1 [26305]: "Sending out a SubSystem change notification. {"subsystems":{"Internet":true,"Location":true}}"
[     170758 us] Activated plugin [TimeSync]:[TimeSync]
-     L1 [26305]: "Timesync: Send data: 48 bytes"
-     L1 [26305]: "Timesync: Received data: 48 bytes"
-     L1 [26305]: "Request time diff  = 0.018794"
-     L1 [26305]: "Response time diff = 0.470260"
-     L1 [26305]: "Offset time        = 0.244527"
-     L1 [26305]: "Server elapsed time = 0.000037"
-     L1 [26305]: "Total elapsed time  = -0.451429"
-     L1 [26305]: "Round trip time     = -0.451466"
-     L1 [26305]: "TimeSync: Closing socket, no longer needed"
-     L1 [26305]: "Failed to set system time [1]"
-     L1 [26305]: "Waking up again at Sat, 06 Apr 2019 12:26:05 GMT."
[     227058 us] EVENT: Time: Fri, 05 Apr 2019 12:26:05 GMT
-     L1 [26305]: "Sending out a SubSystem change notification. {"subsystems":{"Time":true}}"
    #0 0x7fd7fce6b048 in __interceptor_realloc (/lib64/libasan.so.5+0xf0048)
    #1 0x7fd7fca93842 in void WPEFramework::Core::FrameType<(unsigned short)512>::AllocatorType<(unsigned short)512>::RealAllocate<(unsigned short)512>(unsigned int, TemplateIntToType<(unsigned short)512> const&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xee842)
    #2 0x7fd7fca8d813 in WPEFramework::Core::FrameType<(unsigned short)512>::AllocatorType<(unsigned short)512>::Allocate(unsigned int) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xe8813)
    #3 0x7fd7fca86088 in WPEFramework::Core::FrameType<(unsigned short)512>::Size(unsigned short) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xe1088)
    #4 0x7fd7fca8eae5 in unsigned short WPEFramework::Core::FrameType<(unsigned short)512>::SetBuffer<unsigned short>(unsigned short, unsigned short const&, unsigned char const*) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xe9ae5)
    #5 0x7fd7fca86926 in WPEFramework::Core::FrameType<(unsigned short)512>::SetText(unsigned short, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xe1926)
    #6 0x7fd7fca89555 in WPEFramework::Core::FrameType<(unsigned short)512>::Writer::Text(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xe4555)
    #7 0x7fd7f9c6eb75 in WPEFramework::ProxyStubs::{lambda(WPEFramework::Core::ProxyType<WPEFramework::Core::IPCChannel>&, WPEFramework::Core::ProxyType<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >&)#6}::operator()(WPEFramework::Core::ProxyType<WPEFramework::Core::IPCChannel>&, WPEFramework::Core::ProxyType<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >&) const (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/wpeframework/proxystubs/libWPEFrameworkProxyStubs.so+0x31b75)
    #8 0x7fd7f9c6ecb9 in WPEFramework::ProxyStubs::{lambda(WPEFramework::Core::ProxyType<WPEFramework::Core::IPCChannel>&, WPEFramework::Core::ProxyType<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >&)#6}::_FUN(WPEFramework::Core::ProxyType<WPEFramework::Core::IPCChannel>&, WPEFramework::Core::ProxyType<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/wpeframework/proxystubs/libWPEFrameworkProxyStubs.so+0x31cb9)
    #9 0x7fd7f9ca628e in WPEFramework::ProxyStub::UnknownStubType<WPEFramework::PluginHost::IShell, &WPEFramework::ProxyStubs::ShellStubMethods>::Handle(unsigned short, WPEFramework::Core::ProxyType<WPEFramework::Core::IPCChannel>&, WPEFramework::Core::ProxyType<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/wpeframework/proxystubs/libWPEFrameworkProxyStubs.so+0x6928e)
    #10 0x7fd7fcad251f in WPEFramework::RPC::Administrator::Invoke(WPEFramework::Core::ProxyType<WPEFramework::Core::IPCChannel>&, WPEFramework::Core::ProxyType<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0x12d51f)
    #11 0x65ea65 in WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info::Dispatch() (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x65ea65)
    #12 0x658f47 in WPEFramework::Core::ThreadPoolType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info, (unsigned short)3, 16u>::ThreadUnitType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info>::Worker() (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x658f47)
    #13 0x7fd7fc87a735 in WPEFramework::Core::Thread::StartThread(WPEFramework::Core::Thread*) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkCore.so.1+0xf0735)
    #14 0x7fd7fc26758d in start_thread /usr/src/debug/glibc-2.28-60-g4d7af7815a/nptl/pthread_create.c:486
    #15 0x7fd7fc38a6a2 in clone (/lib64/libc.so.6+0xfd6a2)

0x615000010700 is located 0 bytes inside of 512-byte region [0x615000010700,0x615000010900)
allocated by thread T9 here:
    #0 0x7fd7fce6ca10 in operator new[](unsigned long) (/lib64/libasan.so.5+0xf1a10)
    #1 0x7fd7fca8d499 in WPEFramework::Core::FrameType<(unsigned short)512>::AllocatorType<(unsigned short)512>::AllocatorType() (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xe8499)
    #2 0x7fd7fca85f40 in WPEFramework::Core::FrameType<(unsigned short)512>::FrameType() (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xe0f40)
    #3 0x7fd7fca80ab6 in WPEFramework::RPC::Data::Frame::Frame() (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xdbab6)
    #4 0x7fd7fca810a0 in WPEFramework::RPC::Data::Output::Output() (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xdc0a0)
    #5 0x7fd7fca99d28 in WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output>::RawSerializedType<WPEFramework::RPC::Data::Output, 5u>::RawSerializedType(WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output>&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xf4d28)
    #6 0x7fd7fca98830 in WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output>::IPCMessageType() (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xf3830)
    #7 0x7fd7fca9659d in WPEFramework::Core::ProxyObject<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >::ProxyObject() (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xf159d)
    #8 0x7fd7fca93e69 in WPEFramework::Core::ProxyPoolType<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >::ProxyObjectType<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >::ProxyObjectType(WPEFramework::Core::ProxyPoolType<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >*) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xeee69)
    #9 0x7fd7fca8f4b1 in WPEFramework::Core::ProxyPoolType<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >::ProxyObjectType<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >::Create(WPEFramework::Core::ProxyPoolType<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xea4b1)
    #10 0x7fd7fca873a9 in WPEFramework::Core::ProxyPoolType<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >::Element() (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0xe23a9)
    #11 0x7fd7fcb0f8a2 in WPEFramework::Core::FactoryType<WPEFramework::Core::IIPC, unsigned int>::InternalFactoryType<WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output> >::GetElement() (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkProtocols.so.1+0x16a8a2)
    #12 0x7fd7fccd0777 in WPEFramework::Core::FactoryType<WPEFramework::Core::IIPC, unsigned int>::Element(unsigned int const&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkPlugins.so.1+0x12e777)
    #13 0x7fd7fcccaa00 in WPEFramework::Core::IPCChannel::IPCFactory::Element(unsigned int const&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkPlugins.so.1+0x128a00)
    #14 0x7fd7fcd0e251 in WPEFramework::Core::LinkType<WPEFramework::Core::SocketPort, WPEFramework::Core::IMessage, WPEFramework::Core::IMessage, WPEFramework::Core::IPCChannel::IPCFactory&>::DeserializerImpl::Element(unsigned int const&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkPlugins.so.1+0x16c251)
    #15 0x7fd7fccc8c75 in WPEFramework::Core::IMessage::Deserializer::Deserialize(unsigned char const*, unsigned short) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkPlugins.so.1+0x126c75)
    #16 0x7fd7fcd105d1 in WPEFramework::Core::LinkType<WPEFramework::Core::SocketPort, WPEFramework::Core::IMessage, WPEFramework::Core::IMessage, WPEFramework::Core::IPCChannel::IPCFactory&>::ReceiveData(unsigned char*, unsigned short) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkPlugins.so.1+0x16e5d1)
    #17 0x7fd7fcd0f069 in WPEFramework::Core::LinkType<WPEFramework::Core::SocketPort, WPEFramework::Core::IMessage, WPEFramework::Core::IMessage, WPEFramework::Core::IPCChannel::IPCFactory&>::HandlerType<WPEFramework::Core::LinkType<WPEFramework::Core::SocketPort, WPEFramework::Core::IMessage, WPEFramework::Core::IMessage, WPEFramework::Core::IPCChannel::IPCFactory&>, WPEFramework::Core::SocketPort>::ReceiveData(unsigned char*, unsigned short) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkPlugins.so.1+0x16d069)
    #18 0x7fd7fc870e9f in WPEFramework::Core::SocketPort::Read() (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkCore.so.1+0xe6e9f)
    #19 0x7fd7fc86f731 in WPEFramework::Core::SocketPort::Handle(unsigned short) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkCore.so.1+0xe5731)
    #20 0x7fd7fc86050d in WPEFramework::Core::ResourceMonitorType<WPEFramework::Core::IResource, WPEFramework::Core::Void>::Worker() (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkCore.so.1+0xd650d)
    #21 0x7fd7fc85ef86 in WPEFramework::Core::ResourceMonitorType<WPEFramework::Core::IResource, WPEFramework::Core::Void>::MonitorWorker::Worker() (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkCore.so.1+0xd4f86)
    #22 0x7fd7fc87a735 in WPEFramework::Core::Thread::StartThread(WPEFramework::Core::Thread*) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkCore.so.1+0xf0735)
    #23 0x7fd7fc26758d in start_thread /usr/src/debug/glibc-2.28-60-g4d7af7815a/nptl/pthread_create.c:486

Thread T5 created by T0 here:
    #0 0x7fd7fcdcdf63 in __interceptor_pthread_create (/lib64/libasan.so.5+0x52f63)
    #1 0x7fd7fc87a0c6 in WPEFramework::Core::Thread::Thread(unsigned int, char const*) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkCore.so.1+0xf00c6)
    #2 0x6579ff in WPEFramework::Core::ThreadPoolType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info, (unsigned short)3, 16u>::ThreadUnitType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info>::ThreadUnitType(WPEFramework::Core::QueueType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info>&, unsigned int, char const*) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x6579ff)
    #3 0x655ee7 in void __gnu_cxx::new_allocator<WPEFramework::Core::ThreadPoolType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info, (unsigned short)3, 16u>::ThreadUnitType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info> >::construct<WPEFramework::Core::ThreadPoolType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info, (unsigned short)3, 16u>::ThreadUnitType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info>, WPEFramework::Core::QueueType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info>&, unsigned int const&, char const*&>(WPEFramework::Core::ThreadPoolType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info, (unsigned short)3, 16u>::ThreadUnitType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info>*, WPEFramework::Core::QueueType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info>&, unsigned int const&, char const*&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x655ee7)
    #4 0x652b98 in void std::allocator_traits<std::allocator<WPEFramework::Core::ThreadPoolType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info, (unsigned short)3, 16u>::ThreadUnitType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info> > >::construct<WPEFramework::Core::ThreadPoolType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info, (unsigned short)3, 16u>::ThreadUnitType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info>, WPEFramework::Core::QueueType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info>&, unsigned int const&, char const*&>(std::allocator<WPEFramework::Core::ThreadPoolType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info, (unsigned short)3, 16u>::ThreadUnitType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info> >&, WPEFramework::Core::ThreadPoolType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info, (unsigned short)3, 16u>::ThreadUnitType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info>*, WPEFramework::Core::QueueType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info>&, unsigned int const&, char const*&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x652b98)
    #5 0x64e0e3 in void std::vector<WPEFramework::Core::ThreadPoolType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info, (unsigned short)3, 16u>::ThreadUnitType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info>, std::allocator<WPEFramework::Core::ThreadPoolType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info, (unsigned short)3, 16u>::ThreadUnitType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info> > >::emplace_back<WPEFramework::Core::QueueType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info>&, unsigned int const&, char const*&>(WPEFramework::Core::QueueType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info>&, unsigned int const&, char const*&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x64e0e3)
    #6 0x645df3 in WPEFramework::Core::ThreadPoolType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::Info, (unsigned short)3, 16u>::ThreadPoolType(unsigned int, char const*) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x645df3)
    #7 0x638adc in WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3>::InvokeServerType(unsigned int) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x638adc)
    #8 0x626381 in WPEFramework::Core::ProxyObject<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3> >::ProxyObject<unsigned int>(unsigned int) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x626381)
    #9 0x616cc9 in WPEFramework::Core::ProxyType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3> > WPEFramework::Core::ProxyType<WPEFramework::RPC::InvokeServerType<16u, (unsigned short)3> >::Create<unsigned int>(unsigned int) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x616cc9)
    #10 0x5fd4c4 in WPEFramework::PluginHost::Server::ServiceMap::CommunicatorServer::CommunicatorServer(WPEFramework::Core::NodeId const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x5fd4c4)
    #11 0x60125f in WPEFramework::PluginHost::Server::ServiceMap::ServiceMap(WPEFramework::PluginHost::Server&, WPEFramework::PluginHost::Config&, unsigned int) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x60125f)
    #12 0x5d8150 in WPEFramework::PluginHost::Server::Server(WPEFramework::PluginHost::Server::Config&, WPEFramework::PluginHost::ISecurity*, bool) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x5d8150)
    #13 0x5b5648 in main (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x5b5648)
    #14 0x7fd7fc2b1412 in __libc_start_main ../csu/libc-start.c:308

Thread T9 created by T0 here:
    #0 0x7fd7fcdcdf63 in __interceptor_pthread_create (/lib64/libasan.so.5+0x52f63)
    #1 0x7fd7fc87a0c6 in WPEFramework::Core::Thread::Thread(unsigned int, char const*) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkCore.so.1+0xf00c6)
    #2 0x7fd7fc85da04 in WPEFramework::Core::ResourceMonitorType<WPEFramework::Core::IResource, WPEFramework::Core::Void>::MonitorWorker::MonitorWorker(WPEFramework::Core::ResourceMonitorType<WPEFramework::Core::IResource, WPEFramework::Core::Void>&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkCore.so.1+0xd3a04)
    #3 0x7fd7fc85d042 in WPEFramework::Core::ResourceMonitorType<WPEFramework::Core::IResource, WPEFramework::Core::Void>::Register(WPEFramework::Core::IResource&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkCore.so.1+0xd3042)
    #4 0x7fd7fc86c427 in WPEFramework::Core::SocketPort::Open(unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/lib/libWPEFrameworkCore.so.1+0xe2427)
    #5 0x52a1b7 in WPEFramework::Core::SocketPort::Open(unsigned int) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x52a1b7)
    #6 0x5dc2a8 in WPEFramework::Core::SocketListner::Open(unsigned int) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x5dc2a8)
    #7 0x5e52b9 in WPEFramework::RPC::Communicator::Open(unsigned int) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x5e52b9)
    #8 0x5fdae7 in WPEFramework::PluginHost::Server::ServiceMap::CommunicatorServer::CommunicatorServer(WPEFramework::Core::NodeId const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x5fdae7)
    #9 0x60125f in WPEFramework::PluginHost::Server::ServiceMap::ServiceMap(WPEFramework::PluginHost::Server&, WPEFramework::PluginHost::Config&, unsigned int) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x60125f)
    #10 0x5d8150 in WPEFramework::PluginHost::Server::Server(WPEFramework::PluginHost::Server::Config&, WPEFramework::PluginHost::ISecurity*, bool) (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x5d8150)
    #11 0x5b5648 in main (/home/dwrobel/projects/webkit/WebPlatformForEmbedded-1/_install/usr/bin/WPEFramework-1.0.0+0x5b5648)
    #12 0x7fd7fc2b1412 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch (/lib64/libasan.so.5+0xf0048) in __interceptor_realloc
==26305==ABORTING