### PR TITLE
Avoid polutting global namespace with `OK` define.

### DIFF
--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -371,9 +371,7 @@ typedef DEPRECATED signed long long sint64;
 #define TRUE (!FALSE)
 #endif
 
-#ifndef OK
-#define OK (0)
-#endif
+namespace WPEFramework { constexpr uint32_t OK = 0; }
 
 #ifdef __WIN32__
 #define SYSTEM_SYNC_HANDLE HANDLE


### PR DESCRIPTION
Fixes clash with playready:

sysroots/dcx960-debug/usr/include/playready3x/bignum.h: In function 'DRM_BOOL PK::multiply(const digit_t*, DRM_DWORD, const digit_t*, DRM_DWORD, digit_t*)':
sysroots/dcx960-debug/usr/include/playready3x/bignum.h:565:21: error: lvalue required as left operand of assignment
         DRM_BOOL OK = TRUE;                                             \
                     ^