### PR TITLE
Opencdm Update API Timeout/Lockup issues.

### DIFF
--- a/Source/ocdm/ExtendedOpenCDMSession.h
+++ b/Source/ocdm/ExtendedOpenCDMSession.h
@@ -204,9 +204,15 @@ public:
         _state = static_cast<sessionState>(_state & (~(SESSION_UPDATE | SESSION_MESSAGE)));
 
         OpenCDMSession::Update(pbResponse, cbResponse);
+	// If we build in release, we do not want to "hang" forever, forcefull close after 20S waiting...
+	#ifdef __DEBUG__
+	unsigned int a_Time = WPEFramework::Core::infinite;
+	#else
+	unsigned int a_Time = 20000;// Expect time in MS
+	#endif
 
         _state.WaitState(SESSION_UPDATE | SESSION_MESSAGE,
-            WPEFramework::Core::infinite);
+            a_Time);
         if ((_state & SESSION_MESSAGE) == SESSION_MESSAGE) {
             response = "message:" + _message;
         }

--- a/Source/ocdm/ExtendedOpenCDMSession.h
+++ b/Source/ocdm/ExtendedOpenCDMSession.h
@@ -156,9 +156,15 @@ public:
     {
 
         ASSERT(IsValid() == true);
+	// If we build in release, we do not want to "hang" forever, forcefull close after 5S waiting...
+        #ifdef __DEBUG__
+        unsigned int a_Time = WPEFramework::Core::infinite;
+        #else
+        unsigned int a_Time = 5000;// Expect time in MS
+        #endif	
 
         _state.WaitState(SESSION_MESSAGE | SESSION_READY,
-            WPEFramework::Core::infinite);
+            a_Time);
 
         if ((_state & SESSION_MESSAGE) == SESSION_MESSAGE) {
             challenge = _message;
@@ -184,8 +190,14 @@ public:
         response.clear();
 
         if (OpenCDMSession::Load() == 0) {
+  	     // If we build in release, we do not want to "hang" forever, forcefull close after 5S waiting...
+             #ifdef __DEBUG__
+             unsigned int a_Time = WPEFramework::Core::infinite;
+             #else
+             unsigned int a_Time = 5000;// Expect time in MS
+             #endif
 
-            _state.WaitState(SESSION_UPDATE, WPEFramework::Core::infinite);
+            _state.WaitState(SESSION_UPDATE, a_Time);
 
             if (_key == OCDM::ISession::Usable) {
                 ret = 0;
@@ -204,14 +216,14 @@ public:
         _state = static_cast<sessionState>(_state & (~(SESSION_UPDATE | SESSION_MESSAGE)));
 
         OpenCDMSession::Update(pbResponse, cbResponse);
-	// If we build in release, we do not want to "hang" forever, forcefull close after 20S waiting...
+	// If we build in release, we do not want to "hang" forever, forcefull close after 5S waiting...
 	#ifdef __DEBUG__
 	unsigned int a_Time = WPEFramework::Core::infinite;
 	#else
-	unsigned int a_Time = 20000;// Expect time in MS
+	unsigned int a_Time = 5000;// Expect time in MS
 	#endif
 
-        _state.WaitState(SESSION_UPDATE | SESSION_MESSAGE,
+        _state.WaitState(SESSION_UPDATE | SESSION_MESSAGE | SESSION_ERROR,
             a_Time);
         if ((_state & SESSION_MESSAGE) == SESSION_MESSAGE) {
             response = "message:" + _message;
@@ -226,8 +238,14 @@ public:
         _state = static_cast<sessionState>(_state & (~(SESSION_UPDATE | SESSION_MESSAGE)));
 
         if (OpenCDMSession::Remove() == 0) {
+	    // If we build in release, we do not want to "hang" forever, forcefull close after 5S waiting...
+             #ifdef __DEBUG__
+             unsigned int a_Time = WPEFramework::Core::infinite;
+             #else
+             unsigned int a_Time = 5000;// Expect time in MS
+             #endif
 
-            _state.WaitState(SESSION_UPDATE, WPEFramework::Core::infinite);
+            _state.WaitState(SESSION_UPDATE, a_Time);
 
             if (_key == OCDM::ISession::StatusPending) {
                 ret = 0;

--- a/Source/ocdm/ExtendedOpenCDMSession.h
+++ b/Source/ocdm/ExtendedOpenCDMSession.h
@@ -8,6 +8,13 @@
 #include "open_cdm_impl.h"
 using namespace WPEFramework;
 
+// If we build in release, we do not want to "hang" forever, forcefull close after 5S waiting...
+#ifdef __DEBUG__
+unsigned int a_Time = WPEFramework::Core::infinite;
+#else
+unsigned int a_Time = 5000;// Expect time in MS
+#endif
+
 extern Core::CriticalSection _systemLock;
 extern const char EmptyString[];
 
@@ -156,12 +163,6 @@ public:
     {
 
         ASSERT(IsValid() == true);
-	// If we build in release, we do not want to "hang" forever, forcefull close after 5S waiting...
-        #ifdef __DEBUG__
-        unsigned int a_Time = WPEFramework::Core::infinite;
-        #else
-        unsigned int a_Time = 5000;// Expect time in MS
-        #endif	
 
         _state.WaitState(SESSION_MESSAGE | SESSION_READY,
             a_Time);
@@ -190,12 +191,6 @@ public:
         response.clear();
 
         if (OpenCDMSession::Load() == 0) {
-  	     // If we build in release, we do not want to "hang" forever, forcefull close after 5S waiting...
-             #ifdef __DEBUG__
-             unsigned int a_Time = WPEFramework::Core::infinite;
-             #else
-             unsigned int a_Time = 5000;// Expect time in MS
-             #endif
 
             _state.WaitState(SESSION_UPDATE, a_Time);
 
@@ -216,12 +211,6 @@ public:
         _state = static_cast<sessionState>(_state & (~(SESSION_UPDATE | SESSION_MESSAGE)));
 
         OpenCDMSession::Update(pbResponse, cbResponse);
-	// If we build in release, we do not want to "hang" forever, forcefull close after 5S waiting...
-	#ifdef __DEBUG__
-	unsigned int a_Time = WPEFramework::Core::infinite;
-	#else
-	unsigned int a_Time = 5000;// Expect time in MS
-	#endif
 
         _state.WaitState(SESSION_UPDATE | SESSION_MESSAGE | SESSION_ERROR,
             a_Time);
@@ -238,12 +227,6 @@ public:
         _state = static_cast<sessionState>(_state & (~(SESSION_UPDATE | SESSION_MESSAGE)));
 
         if (OpenCDMSession::Remove() == 0) {
-	    // If we build in release, we do not want to "hang" forever, forcefull close after 5S waiting...
-             #ifdef __DEBUG__
-             unsigned int a_Time = WPEFramework::Core::infinite;
-             #else
-             unsigned int a_Time = 5000;// Expect time in MS
-             #endif
 
             _state.WaitState(SESSION_UPDATE, a_Time);
 


### PR DESCRIPTION
For Fixing Issue #130
OpenCdm::Update API goes into a wait state with infinite wait.
In cases where the License Server or application provides
an Incorrect License Response blob to the opencdm update API
the caller thread gets blocked infinitely.