### PR TITLE
[Communicator-Offer] used true always for the IsRequest() case, since…

### DIFF
--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -895,7 +895,7 @@ namespace RPC {
 
                     ASSERT(result != nullptr);
 
-                    Core::IUnknown* baseIUnknown = Administrator::Instance().ProxyInstance<Core::IUnknown>(channel, result, info.InterfaceId(), info.IsRequested());
+                    Core::IUnknown* baseIUnknown = Administrator::Instance().ProxyInstance<Core::IUnknown>(channel, result, info.InterfaceId(), true);
 
                     if (baseIUnknown != nullptr) {
                         _parent.Offer(baseIUnknown, info.InterfaceId());


### PR DESCRIPTION
… it maintain one state

The Message is handling only one type at a time, so the IsRequested() during the Offer will 0 always. so changed this to hardcoded true to save the proxy instance details