### PR TITLE
Sebaszm/combined streamer

### DIFF
--- a/Source/interfaces/Definitions.cpp
+++ b/Source/interfaces/Definitions.cpp
@@ -40,10 +40,16 @@ ENUM_CONVERSION_BEGIN(Exchange::IComposition::ScreenResolution)
 ENUM_CONVERSION_END(Exchange::IComposition::ScreenResolution)
 
 ENUM_CONVERSION_BEGIN(Exchange::IStream::streamtype)
-    { Exchange::IStream::Stubbed, _TXT("Stubbed") },
-    { Exchange::IStream::DVB,     _TXT("DVB")     },
-    { Exchange::IStream::ATSC,     _TXT("ATSC")     },
-    { Exchange::IStream::VOD,     _TXT("VOD")     },
+    { Exchange::IStream::Undefined,   _TXT("Unknown")     },
+    { Exchange::IStream::Cable,       _TXT("Cable")       },
+    { Exchange::IStream::Handheld,    _TXT("Handheld")    },
+    { Exchange::IStream::Satellite,   _TXT("Satellite")   },
+    { Exchange::IStream::Terrestrial, _TXT("Terrestrial") },
+    { Exchange::IStream::DAB,         _TXT("DAB")         },
+    { Exchange::IStream::RF,          _TXT("RF")          },
+    { Exchange::IStream::Unicast,     _TXT("Unicast")     },
+    { Exchange::IStream::Multicast,   _TXT("Multicast")   },
+    { Exchange::IStream::IP,          _TXT("IP")          },
 ENUM_CONVERSION_END(Exchange::IStream::streamtype)
 
 ENUM_CONVERSION_BEGIN(Exchange::IStream::state)

--- a/Source/interfaces/IStream.h
+++ b/Source/interfaces/IStream.h
@@ -1,5 +1,4 @@
-#ifndef _ISTREAM_H
-#define _ISTREAM_H
+#pragma once
 
 #include "Module.h"
 
@@ -21,11 +20,17 @@ namespace Exchange {
         };
 
         enum streamtype {
-            Stubbed = 0,
-            DVB,
-            ATSC,
-            VOD
-        };
+            Undefined = 0,
+            Cable = 1,
+            Handheld = 2,
+            Satellite = 4,
+            Terrestrial = 8,
+            DAB = 16,
+            RF = 31,
+            Unicast = 32,
+            Multicast = 64,
+            IP = 96
+       };
 
         enum drmtype {
             None = 0,
@@ -98,26 +103,6 @@ namespace Exchange {
         virtual IStream* CreateStream(const IStream::streamtype streamType) = 0;
         virtual uint32_t Configure(PluginHost::IShell* service) = 0;
     };
+
 } // namespace Exchange
-
-namespace Player {
-    namespace Implementation {
-
-        struct Rectangle {
-            uint32_t X;
-            uint32_t Y;
-            uint32_t Width;
-            uint32_t Height;
-        };
-
-        struct ICallback {
-            virtual ~ICallback() {}
-
-            virtual void TimeUpdate(uint64_t position) = 0;
-            virtual void DRM(uint32_t state) = 0;
-            virtual void StateChange(Exchange::IStream::state newState) = 0;
-        };
-    }
-} // // namespace Player::Implementation
-} // namespace WPEFramework
-#endif //_ISTREAM_H
+}

--- a/Source/interfaces/json/StreamerAPI.json
+++ b/Source/interfaces/json/StreamerAPI.json
@@ -10,6 +10,17 @@
     "$ref": "common.json"
   },
   "definitions": {
+    "id": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Stream ID",
+          "type": "number",
+          "size": 8,
+          "example": 0
+        }
+      }
+    },
     "stream": {
       "type": "string",
       "enum": [
@@ -101,8 +112,9 @@
     "speed": {
       "summary": "Playback speed",
       "description": "Speed (in percentage)",
+      "events": "statechange",
       "params": {
-        "description": "Speed percentage; e.g.: 0 - pause, 100 - normal playback, -100 - rewind, -200 - reverse at twice the speed, 50 - forward at half speed, etc.",
+        "description": "Speed percentage; e.g.: 0 - pause, 100 - normal playback, -100 - rewind, -200 - reverse at twice the speed, 50 - forward at half speed, etc. Must be one of the speeds supported by the player",
         "type": "number",
         "signed": true,
         "example": 100
@@ -148,12 +160,7 @@
     "window": {
       "summary": "Stream playback window",
       "params": {
-        "type": "object",
-        "properties": {
-          "window": {
-            "$ref": "#/definitions/window"
-          }
-        }
+       "$ref": "#/definitions/window"
       },
       "index": {
         "name": "Stream ID",
@@ -228,12 +235,7 @@
       "summary": "Type of a stream",
       "readonly": true,
       "params": {
-        "type": "object",
-        "properties": {
-          "stream": {
-            "$ref": "#/definitions/stream"
-          }
-        }
+        "$ref": "#/definitions/stream"
       },
       "index": {
         "name": "Stream ID",
@@ -253,12 +255,7 @@
         "drmchange"
       ],
       "params": {
-        "type": "object",
-        "properties": {
-          "drm": {
-            "$ref": "#/definitions/drm"
-          }
-        }
+        "$ref": "#/definitions/drm"
       },
       "index": {
         "name": "Stream ID",
@@ -278,12 +275,26 @@
         "statechange"
       ],
       "params": {
-        "type": "object",
-        "properties": {
-          "state": {
-            "$ref": "#/definitions/state"
-          }
+        "$ref": "#/definitions/state"
+      },
+      "index": {
+        "name": "Stream ID",
+        "example": "0"
+      },
+      "errors": [
+        {
+          "description": "Unknown stream ID given",
+          "$ref": "#/common/errors/unknownkey"
         }
+      ]
+    },
+    "metadata": {
+      "readonly": true,
+      "summary": "Metadata associated with the stream",
+      "params": {
+        "type": "string",
+        "description": "Custom player-specific metadata",
+        "example": ""
       },
       "index": {
         "name": "Stream ID",
@@ -298,53 +309,6 @@
     }
   },
   "methods": {
-    "Streamer.1.status": {
-      "summary": "Retrieves the status of a stream.",
-      "params": {
-        "description": "Stream ID",
-        "type": "number",
-        "size": 8,
-        "example": 0
-      },
-      "result": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "$ref": "#/definitions/stream"
-          },
-          "state": {
-            "$ref": "#/definitions/state"
-          },
-          "metadata": {
-            "description": "Custom metadata associated with the stream",
-            "type": "string"
-          },
-          "drm": {
-            "$ref": "#/definitions/drm"
-          },
-          "position": {
-            "description": "Stream position (in milliseconds)",
-            "type": "number",
-            "example": 60000,
-            "size": 64
-          },
-          "window": {
-            "$ref": "#/definitions/window"
-          }
-        },
-        "required": [
-          "type",
-          "state",
-          "drm"
-        ]
-      },
-      "errors": [
-        {
-          "description": "Unknown stream ID given",
-          "$ref": "#/common/errors/unknownkey"
-        }
-      ]
-    },
     "Streamer.1.create": {
       "summary": "Creates a stream instance.",
       "params": {
@@ -356,10 +320,7 @@
         }
       },
       "result": {
-        "type": "number",
-        "size": 8,
-        "description": "Stream ID",
-        "example": 0
+        "$ref": "#/definitions/id/properties/id"
       },
       "errors": [
         {
@@ -375,10 +336,7 @@
     "Streamer.1.destroy": {
       "summary": "Destroys a stream instance.",
       "params": {
-        "description": "ID of the streamer instance to be destroyed",
-        "type": "number",
-        "size": 8,
-        "example": 0
+        "$ref": "#/definitions/id"
       },
       "result": {
         "$ref": "#/common/results/void"
@@ -392,14 +350,12 @@
     },
     "Streamer.1.load": {
       "summary": "Loads a source into a stream.",
+      "events": "statechange",
       "params": {
         "type": "object",
         "properties": {
-          "index": {
-            "description": "ID of the streamer instance",
-            "type": "number",
-            "size": 8,
-            "example": 0
+          "id": {
+            "$ref": "#/definitions/id/properties/id"
           },
           "location": {
             "description": "Location of the source to load",
@@ -437,10 +393,7 @@
     "Streamer.1.attach": {
       "summary": "Attaches a decoder to the streamer.",
       "params": {
-        "description": "ID of the streamer instance to attach a decoder to",
-        "type": "number",
-        "size": 8,
-        "example": 0
+        "$ref": "#/definitions/id"
       },
       "result": {
         "$ref": "#/common/results/void"
@@ -467,10 +420,7 @@
     "Streamer.1.detach": {
       "summary": "Detaches a decoder from the streamer.",
       "params": {
-        "description": "ID of the streamer instance to detach the decoder from",
-        "type": "number",
-        "size": 8,
-        "example": 0
+        "$ref": "#/definitions/id"
       },
       "result": {
         "$ref": "#/common/results/void"
@@ -496,7 +446,7 @@
       "summary": "Notifies of stream state change.",
       "example": "1.*",
       "id": {
-        "name": "Streamr ID",
+        "name": "Stream ID",
         "example": "0"
       },
       "params": {

--- a/Source/interfaces/json/StreamerAPI.json
+++ b/Source/interfaces/json/StreamerAPI.json
@@ -13,13 +13,32 @@
     "stream": {
       "type": "string",
       "enum": [
-        "stubbed",
-        "dvb",
-        "atsc",
-        "vod"
+        "undefined",
+        "cable",
+        "handheld",
+        "satellite",
+        "terrestrial",
+        "dab",
+        "rf",
+        "unicast",
+        "multicast",
+        "ip"
       ],
+      "enumvalues": [
+        0,
+        1,
+        2,
+        4,
+        8,
+        16,
+        31,
+        32,
+        64,
+        96
+      ],
+      "enumtyped": false,
       "description": "Stream type",
-      "example": "vod"
+      "example": "cable"
     },
     "state": {
       "description": "Stream state",
@@ -80,16 +99,16 @@
   },
   "properties": {
     "speed": {
-      "summary": "Playback speed.",
-      "description": "Speed in percentage, -200, -100, 0, 100, 200, 400 etc",
+      "summary": "Playback speed",
+      "description": "Speed (in percentage)",
       "params": {
-        "description": "Speed to set; 0 - pause, 100 - normal playback forward, -100 - normal playback back, -200 - reverse at twice the speed, 50 - forward at half speed",
+        "description": "Speed percentage; e.g.: 0 - pause, 100 - normal playback, -100 - rewind, -200 - reverse at twice the speed, 50 - forward at half speed, etc.",
         "type": "number",
         "signed": true,
         "example": 100
       },
       "index": {
-        "name": "Streamer ID",
+        "name": "Stream ID",
         "example": "0"
       },
       "errors": [
@@ -98,39 +117,27 @@
           "$ref": "#/common/errors/unknownkey"
         },
         {
-          "description": "Invalid speed given",
-          "$ref": "#/common/errors/badrequest"
-        },
-        {
           "description": "Player is not in a valid state or decoder not attached",
           "$ref": "#/common/errors/illegalstate"
-        },
-        {
-          "description": "Player instance is not available",
-          "$ref": "#/common/errors/unavailable"
         }
       ]
     },
     "position": {
-      "summary": "Stream position.",
+      "summary": "Stream position",
       "params": {
-        "description": "Position to set (in milliseconds)",
+        "description": "Position (in milliseconds)",
         "type": "number",
         "example": 60000,
         "size": 64
       },
       "index": {
-        "name": "Streamer ID",
+        "name": "Stream ID",
         "example": "0"
       },
       "errors": [
         {
           "description": "Unknown stream ID given",
           "$ref": "#/common/errors/unknownkey"
-        },
-        {
-          "description": "Invalid position given",
-          "$ref": "#/common/errors/badrequest"
         },
         {
           "description": "Player is not in a valid state or decoder not attached",
@@ -139,7 +146,7 @@
       ]
     },
     "window": {
-      "summary": "Stream playback window.",
+      "summary": "Stream playback window",
       "params": {
         "type": "object",
         "properties": {
@@ -149,7 +156,7 @@
         }
       },
       "index": {
-        "name": "Streamer ID",
+        "name": "Stream ID",
         "example": "0"
       },
       "errors": [
@@ -158,21 +165,17 @@
           "$ref": "#/common/errors/unknownkey"
         },
         {
-          "description": "Invalid window geometry given",
-          "$ref": "#/common/errors/badrequest"
-        },
-        {
           "description": "Player is not in a valid state or decoder not attached",
           "$ref": "#/common/errors/illegalstate"
         }
       ]
     },
     "speeds": {
-      "summary": "Retrieves the speeds supported by the player",
+      "summary": "Speeds supported by the stream player",
       "readonly": true,
       "params": {
         "type": "array",
-        "description": "Supported streams in percentage, 100, 200, 400, ..",
+        "description": "Supported speeds (in percentage)",
         "example": [
           0,
           100,
@@ -185,11 +188,11 @@
         "items": {
           "type": "integer",
           "signed": true,
-          "description": "(Speeds in percentage)"
+          "description": "(speeds in percentage)"
         }
       },
       "index": {
-        "name": "Streamer ID",
+        "name": "Stream ID",
         "example": "0"
       },
       "errors": [
@@ -198,17 +201,17 @@
           "$ref": "#/common/errors/unknownkey"
         },
         {
-          "description": "Decoder not attached to the stream",
+          "description": "Player is not in a valid state or decoder not attached",
           "$ref": "#/common/errors/illegalstate"
         }
       ]
     },
     "streams": {
-      "summary": "Retrieves all created stream instance IDs.",
+      "summary": "All created stream instance IDs",
       "readonly": true,
       "params": {
         "type": "array",
-        "description": "Streamer IDs",
+        "description": "Stream IDs",
         "example": [
           0,
           1,
@@ -217,12 +220,12 @@
         ],
         "items": {
           "type": "number",
-          "description": "(a streamer ID)"
+          "description": "(a stream ID)"
         }
       }
     },
     "type": {
-      "summary": "Retrieves the streame type - DVB, ATSC or VOD",
+      "summary": "Type of a stream",
       "readonly": true,
       "params": {
         "type": "object",
@@ -233,7 +236,7 @@
         }
       },
       "index": {
-        "name": "Streamer ID",
+        "name": "Stream ID",
         "example": "0"
       },
       "errors": [
@@ -245,7 +248,7 @@
     },
     "drm": {
       "readonly": true,
-      "summary": "Retrieves the DRM Type attached with stream",
+      "summary": "DRM type associated with a stream",
       "events": [
         "drmchange"
       ],
@@ -258,7 +261,7 @@
         }
       },
       "index": {
-        "name": "Streamer ID",
+        "name": "Stream ID",
         "example": "0"
       },
       "errors": [
@@ -270,7 +273,7 @@
     },
     "state": {
       "readonly": true,
-      "summary": "Retrieves the current state of Player",
+      "summary": "Current state of a stream",
       "events": [
         "statechange"
       ],
@@ -283,7 +286,7 @@
         }
       },
       "index": {
-        "name": "Streamer ID",
+        "name": "Stream ID",
         "example": "0"
       },
       "errors": [
@@ -298,7 +301,7 @@
     "Streamer.1.status": {
       "summary": "Retrieves the status of a stream.",
       "params": {
-        "description": "ID of the streamer instance",
+        "description": "Stream ID",
         "type": "number",
         "size": 8,
         "example": 0
@@ -332,7 +335,6 @@
         "required": [
           "type",
           "state",
-          "metadata",
           "drm"
         ]
       },
@@ -356,7 +358,7 @@
       "result": {
         "type": "number",
         "size": 8,
-        "description": "Streamer ID",
+        "description": "Stream ID",
         "example": 0
       },
       "errors": [
@@ -366,7 +368,7 @@
         },
         {
           "$ref": "#/common/errors/unavailable",
-          "description": "Streamer instance is not available"
+          "description": "Fronted of the selected stream type is not available"
         }
       ]
     },
@@ -420,15 +422,15 @@
         },
         {
           "description": "Invalid location given",
-          "$ref": "#/common/errors/badrequest"
+          "$ref": "#/common/errors/incorrecturl"
         },
         {
-          "description": "Player is not in a valid state",
+          "description": "Undefined loading error",
+          "$ref": "#/common/errors/general"
+        },
+        {
+          "description": "Stream is not in a valid state",
           "$ref": "#/common/errors/illegalstate"
-        },
-        {
-          "description": "Player instance is not available",
-          "$ref": "#/common/errors/unavailable"
         }
       ]
     },
@@ -449,17 +451,21 @@
           "$ref": "#/common/errors/unknownkey"
         },
         {
-          "$ref": "#/common/errors/inprogress",
-          "description": "Decoder already attached"
+          "description": "Decoder already attached",
+          "$ref": "#/common/errors/inprogress"
         },
         {
-          "description": "Stream not prepared",
+          "description": "Stream is not in a valid state",
           "$ref": "#/common/errors/illegalstate"
+        },
+        {
+          "description": "No free decoders available",
+          "$ref": "#/common/errors/unavailable"
         }
       ]
     },
     "Streamer.1.detach": {
-      "summary": "Detaches a decoder from the streamer",
+      "summary": "Detaches a decoder from the streamer.",
       "params": {
         "description": "ID of the streamer instance to detach the decoder from",
         "type": "number",
@@ -475,22 +481,22 @@
           "$ref": "#/common/errors/unknownkey"
         },
         {
-          "description": "Decoder not attached to the stream",
+          "description": "Stream is not in a valid state or decoder not attached",
           "$ref": "#/common/errors/illegalstate"
         },
         {
-          "$ref": "#/common/errors/inprogress",
-          "description": "Decoder is in use"
+          "description": "Decoder is in use",
+          "$ref": "#/common/errors/inprogress"
         }
       ]
     }
   },
   "events": {
     "statechange": {
-      "summary": "Notifies of stream state change. ID of the streamer instance shall be passed within the designator.",
+      "summary": "Notifies of stream state change.",
       "example": "1.*",
       "id": {
-        "name": "Streamer ID",
+        "name": "Streamr ID",
         "example": "0"
       },
       "params": {
@@ -506,10 +512,10 @@
       }
     },
     "drmchange": {
-      "summary": "Notifies of stream DRM system change. ID of the streamer instance shall be passed within the designator.",
+      "summary": "Notifies of stream DRM system change.",
       "example": "1.*",
       "id": {
-        "name": "Streamer ID",
+        "name": "Stream ID",
         "example": "0"
       },
       "params": {
@@ -525,10 +531,10 @@
       }
     },
     "timeupdate": {
-      "summary": "Event fired to indicate the position in the stream. This event is fired every second to indicate that the stream has progressed by a second, and event does not fire, if the stream is in paused state",
+      "summary": "Notifies of stream position change. This event is fired every second to indicate that the stream has progressed by a second, and event does not fire, if the stream is in paused state.",
       "example": "20",
       "id": {
-        "name": "Streamer ID",
+        "name": "Stream ID",
         "example": "0"
       },
       "params": {


### PR DESCRIPTION
Redefines the streamtype to cover broader delivery types. 
Also aligns the JSON-RPC interface of streamer to others and remove status method as it's redundant.