### PR TITLE
Bram/add timeout to provisioning

### DIFF
--- a/Source/provisionproxy/AccessProvision.h
+++ b/Source/provisionproxy/AccessProvision.h
@@ -1,5 +1,5 @@
-#ifndef __ACCES_PROVISION_H__
-#define __ACCES_PROVISION_H__
+#ifndef __ACCESS_PROVISION_H__
+#define __ACCESS_PROVISION_H__
 
 extern "C" {
 
@@ -38,4 +38,4 @@ int GetDeviceId(unsigned short MaxIdLength, char Id[]);
 int GetDRMId(const char label[], const unsigned short MaxIdLength, char Id[]);
 }
 
-#endif // __ACCES_PROVISION_H__
+#endif // __ACCESS_PROVISION_H__

--- a/Source/provisionproxy/CMakeLists.txt
+++ b/Source/provisionproxy/CMakeLists.txt
@@ -15,7 +15,6 @@ set(PUBLIC_HEADERS
 target_link_libraries(${TARGET}
         PUBLIC
           ${NAMESPACE}Core::${NAMESPACE}Core
-        PRIVATE
           libprovision::libprovision
         )
 

--- a/Source/provisionproxy/CMakeLists.txt
+++ b/Source/provisionproxy/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(${TARGET} STATIC
         )
 
 set(PUBLIC_HEADERS
-        AccesProvision.h
+        AccessProvision.h
         IPCProvision.h
         )
 

--- a/Source/provisionproxy/IPCProvision.h
+++ b/Source/provisionproxy/IPCProvision.h
@@ -6,6 +6,13 @@
 using namespace WPEFramework;
 
 namespace IPC {
+
+#ifdef __DEBUG__
+    enum { CommunicationTimeOut = Core::infinite }; // Time in ms. Forever
+#else
+    enum { CommunicationTimeOut = 2000 }; // Time in ms. 2 Seconds
+#endif
+
 namespace Provisioning {
 
     class KeyValue {

--- a/Source/provisionproxy/ipclink.cpp
+++ b/Source/provisionproxy/ipclink.cpp
@@ -40,7 +40,7 @@ int GetDeviceId(unsigned short MaxIdLength, char Id[])
     if (_channel.Open(1000) == Core::ERROR_NONE) { // Wait for 1 Second.
 
         Core::ProxyType<Core::IIPC> message(Core::proxy_cast<Core::IIPC>(_deviceId));
-        uint32_t error = _channel.Invoke(message, Core::infinite);
+        uint32_t error = _channel.Invoke(message, IPC::CommunicationTimeOut);
 
         result = -error;
 
@@ -91,7 +91,7 @@ int GetDRMId(const char label[], const unsigned short MaxIdLength, char Id[])
         _drmId->Parameters() = string(label);
         Core::ProxyType<Core::IIPC> message(Core::proxy_cast<Core::IIPC>(_drmId));
 
-        uint32_t error = _channel.Invoke(message, Core::infinite);
+        uint32_t error = _channel.Invoke(message, IPC::CommunicationTimeOut);
         result = -error;
 
         if (error == Core::ERROR_NONE) {


### PR DESCRIPTION
Adding a communication timeout to the provisionproxy IPC. In debug Core::infinite otherwise 2 seconds. 
